### PR TITLE
Setup HTML display for the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,12 @@ To set up this project locally, follow these steps:
 5. Open your browser and navigate to `http://localhost:3000` to view the project.
 
 For detailed information on the project structure and how to contribute, please refer to the project documentation.
+
+## Instructions for Compiling and Serving the Website
+
+To compile the React project and serve the `public/index.html` for viewing the website, follow these steps:
+
+1. Ensure you have a build tool like Webpack or Parcel installed. If not, you can install them by running `npm install -g webpack` (for Webpack) or `npm install -g parcel-bundler` (for Parcel).
+2. Compile the project by running `webpack` (for Webpack) or `parcel build` (for Parcel). This will bundle your JavaScript and CSS files.
+3. Serve the `public/index.html` using a static server. You can use `serve` by running `npm install -g serve` and then `serve -s build` to start the server.
+4. Open your browser and navigate to the URL provided by the static server to view the website.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "slack-website",
+  "version": "1.0.0",
+  "description": "A website project for Slack showcasing React components and services.",
+  "main": "index.js",
+  "scripts": {
+    "build": "webpack --mode production",
+    "start": "serve -s build"
+  },
+  "keywords": [
+    "react",
+    "website",
+    "slack"
+  ],
+  "author": "Rajan Patel",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {
+    "webpack": "^5.0.0",
+    "webpack-cli": "^4.0.0",
+    "serve": "^11.0.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Slack</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,33 @@
+const path = require('path');
+
+module.exports = {
+  // Entry point for the application's JavaScript and CSS
+  entry: {
+    app: './src/index.js',
+    styles: './src/styles.css'
+  },
+  // Loaders for processing JavaScript, JSX, and CSS files
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  },
+  // Output directory and filenames for the compiled assets
+  output: {
+    path: path.resolve(__dirname, 'build'),
+    filename: '[name].bundle.js'
+  }
+};


### PR DESCRIPTION
This pull request introduces the necessary infrastructure to compile and serve the website as a static HTML page, fulfilling the task of displaying the whole website in a single HTML file for web presentation.

- **Adds `public/index.html`:** Creates a basic HTML structure with a title, links to the compiled CSS, a div with id "root" for React to mount, and a script tag linking to the compiled JavaScript file.
- **Updates `README.md`:** Includes detailed instructions on compiling the React project using Webpack or Parcel and serving the `public/index.html` using a static server, making it easier for developers to build and view the website.
- **Introduces `package.json`:** Initializes project dependencies and scripts for building the React project and serving the static files, streamlining the development process.
- **Adds `webpack.config.js`:** Sets up a Webpack configuration to bundle JavaScript and CSS files, with rules for processing JavaScript, JSX, and CSS, and defines the output directory and filenames for the compiled assets, ensuring the project's assets are correctly bundled for production.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Rajan-Patell/GitHub-Workspace-Experiments-/pull/5?shareId=db777df6-b523-42ab-bbb0-1c0a151c259c).